### PR TITLE
Add reverse tower defense browser game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# codex-cat-game
+# Reverse Tower Defense
+
+A lightweight browser game where you command raiders in a reverse tower defense scenario. Instead of placing towers, you spend command points to send units through an entrenched base. The project is built with vanilla HTML, CSS, and JavaScript so it can be deployed directly to GitHub Pages.
+
+## Play the game
+
+1. Serve the repository locally (for example with `python3 -m http.server`) or publish it to GitHub Pages.
+2. Open `index.html` in your browser.
+3. Spend command points on Scouts, Bruisers, or Tanks and try to push at least 20 units through the exit portal before the automated turrets stop them.
+
+## Development
+
+- All assets live in the project root (`index.html`, `style.css`, `game.js`).
+- The game loop is implemented in `game.js` with a simple canvas renderer.
+- No external dependencies are required.
+
+Feel free to customize the path, towers, or unit stats to tweak the difficulty.

--- a/game.js
+++ b/game.js
@@ -1,0 +1,444 @@
+const canvas = document.getElementById("game");
+const ctx = canvas.getContext("2d");
+
+const commandPointsEl = document.getElementById("commandPoints");
+const escapedEl = document.getElementById("escaped");
+const statusEl = document.getElementById("status");
+
+const unitButtons = Array.from(document.querySelectorAll("button[data-unit]"));
+
+const TARGET_ESCAPED = 20;
+const BASE_POINTS = 60;
+const POINTS_PER_SECOND = 12;
+let commandPoints = BASE_POINTS;
+let escapedCount = 0;
+let gameOver = false;
+let timeElapsed = 0;
+let lastMotivation = -Infinity;
+
+const path = [
+  { x: 40, y: 560 },
+  { x: 40, y: 420 },
+  { x: 220, y: 420 },
+  { x: 220, y: 220 },
+  { x: 420, y: 220 },
+  { x: 420, y: 520 },
+  { x: 740, y: 520 },
+  { x: 740, y: 120 },
+  { x: 860, y: 120 },
+];
+
+const unitTypes = {
+  scout: {
+    name: "Scout",
+    speed: 120,
+    health: 35,
+    radius: 10,
+    color: "#22d3ee",
+    cost: 30,
+  },
+  bruiser: {
+    name: "Bruiser",
+    speed: 80,
+    health: 90,
+    radius: 12,
+    color: "#f97316",
+    cost: 55,
+  },
+  tank: {
+    name: "Tank",
+    speed: 55,
+    health: 180,
+    radius: 14,
+    color: "#a855f7",
+    cost: 90,
+  },
+};
+
+class Unit {
+  constructor(type) {
+    this.type = type;
+    this.speed = type.speed;
+    this.maxHealth = type.health;
+    this.health = type.health;
+    this.radius = type.radius;
+    this.color = type.color;
+    this.pathIndex = 0;
+    this.position = { x: path[0].x, y: path[0].y };
+    this.alive = true;
+  }
+
+  update(dt) {
+    if (!this.alive) return;
+    const nextPoint = path[this.pathIndex + 1];
+    if (!nextPoint) {
+      this.alive = false;
+      escapedCount += 1;
+      escapedEl.textContent = escapedCount.toString();
+      if (escapedCount >= TARGET_ESCAPED) {
+        endGame(true);
+      }
+      return;
+    }
+
+    const dx = nextPoint.x - this.position.x;
+    const dy = nextPoint.y - this.position.y;
+    const distance = Math.hypot(dx, dy);
+    if (distance === 0) {
+      this.pathIndex += 1;
+      return;
+    }
+
+    const travel = this.speed * dt;
+    if (travel >= distance) {
+      this.position.x = nextPoint.x;
+      this.position.y = nextPoint.y;
+      this.pathIndex += 1;
+    } else {
+      this.position.x += (dx / distance) * travel;
+      this.position.y += (dy / distance) * travel;
+    }
+  }
+
+  takeDamage(amount) {
+    this.health -= amount;
+    if (this.health <= 0) {
+      this.alive = false;
+    }
+  }
+}
+
+class Tower {
+  constructor(x, y, options = {}) {
+    this.position = { x, y };
+    this.range = options.range ?? 180;
+    this.fireRate = options.fireRate ?? 1.2; // shots per second
+    this.cooldown = 0;
+    this.projectileSpeed = options.projectileSpeed ?? 320;
+    this.damage = options.damage ?? 30;
+  }
+
+  update(dt, units) {
+    this.cooldown -= dt;
+    if (this.cooldown > 0 || gameOver) return;
+
+    let target = null;
+    let maxProgress = -Infinity;
+    for (const unit of units) {
+      if (!unit.alive) continue;
+      const distance = Math.hypot(
+        unit.position.x - this.position.x,
+        unit.position.y - this.position.y
+      );
+      if (distance <= this.range) {
+        const progress = unit.pathIndex + distance * 0.001;
+        if (progress > maxProgress) {
+          maxProgress = progress;
+          target = unit;
+        }
+      }
+    }
+
+    if (target) {
+      projectiles.push(
+        new Projectile(this.position, target, {
+          speed: this.projectileSpeed,
+          damage: this.damage,
+        })
+      );
+      this.cooldown = 1 / this.fireRate;
+    }
+  }
+
+  draw() {
+    const { x, y } = this.position;
+    ctx.save();
+    ctx.fillStyle = "#0f172a";
+    ctx.strokeStyle = "#94a3b8";
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.arc(x, y, 20, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.strokeStyle = "rgba(148, 163, 184, 0.25)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(x, y, this.range, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+class Projectile {
+  constructor(origin, target, options = {}) {
+    this.position = { x: origin.x, y: origin.y };
+    this.target = target;
+    this.speed = options.speed ?? 300;
+    this.damage = options.damage ?? 25;
+    this.radius = 4;
+    this.active = true;
+  }
+
+  update(dt) {
+    if (!this.active) return;
+    if (!this.target.alive) {
+      this.active = false;
+      return;
+    }
+
+    const dx = this.target.position.x - this.position.x;
+    const dy = this.target.position.y - this.position.y;
+    const distance = Math.hypot(dx, dy);
+    const travel = this.speed * dt;
+
+    if (distance <= this.target.radius + this.radius || travel >= distance) {
+      this.target.takeDamage(this.damage);
+      this.active = false;
+      return;
+    }
+
+    this.position.x += (dx / distance) * travel;
+    this.position.y += (dy / distance) * travel;
+  }
+
+  draw() {
+    if (!this.active) return;
+    ctx.save();
+    ctx.fillStyle = "#facc15";
+    ctx.beginPath();
+    ctx.arc(this.position.x, this.position.y, this.radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
+}
+
+const units = [];
+const towers = [];
+const projectiles = [];
+
+function createTowers() {
+  towers.push(new Tower(160, 380, { fireRate: 1.4, range: 200 }));
+  towers.push(new Tower(340, 260, { fireRate: 1.2, damage: 35 }));
+  towers.push(new Tower(520, 420, { fireRate: 1.5, projectileSpeed: 360 }));
+  towers.push(new Tower(640, 200, { fireRate: 0.9, damage: 48, range: 220 }));
+  towers.push(new Tower(820, 300, { fireRate: 1.1, range: 210 }));
+}
+
+function spawnUnit(key) {
+  if (gameOver) return;
+  const type = unitTypes[key];
+  if (!type) return;
+  if (commandPoints < type.cost) {
+    flashStatus(`Not enough command points for a ${type.name}.`);
+    return;
+  }
+  commandPoints -= type.cost;
+  units.push(new Unit(type));
+  flashStatus(`${type.name} deployed!`);
+}
+
+function flashStatus(message) {
+  statusEl.textContent = message;
+  statusEl.classList.add("visible");
+  setTimeout(() => statusEl.classList.remove("visible"), 800);
+}
+
+function endGame(victory) {
+  if (gameOver) return;
+  gameOver = true;
+  statusEl.textContent = victory
+    ? "Raid successful! You overwhelmed the defenses."
+    : "The towers held. Recalibrate your assault.";
+  statusEl.classList.add("visible");
+}
+
+function updateCommandPoints(dt) {
+  if (gameOver) return;
+  commandPoints = Math.min(
+    200,
+    commandPoints + POINTS_PER_SECOND * dt
+  );
+  commandPointsEl.textContent = Math.floor(commandPoints).toString();
+}
+
+function update(dt) {
+  timeElapsed += dt;
+  updateCommandPoints(dt);
+
+  for (const unit of units) {
+    unit.update(dt);
+  }
+
+  for (const tower of towers) {
+    tower.update(dt, units);
+  }
+
+  for (const projectile of projectiles) {
+    projectile.update(dt);
+  }
+
+  for (let i = units.length - 1; i >= 0; i--) {
+    if (!units[i].alive) {
+      units.splice(i, 1);
+    }
+  }
+
+  for (let i = projectiles.length - 1; i >= 0; i--) {
+    if (!projectiles[i].active) {
+      projectiles.splice(i, 1);
+    }
+  }
+
+  if (
+    !gameOver &&
+    units.length === 0 &&
+    commandPoints < 30 &&
+    timeElapsed - lastMotivation > 3
+  ) {
+    // no units on the map and not enough points for the cheapest unit
+    // gently nudge the player to keep trying
+    flashStatus("Regroup! Save up for more units.");
+    lastMotivation = timeElapsed;
+  }
+}
+
+function drawBackground() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.save();
+  ctx.fillStyle = "rgba(12, 20, 32, 0.9)";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = "#1d4ed8";
+  ctx.lineWidth = 28;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(path[0].x, path[0].y);
+  for (let i = 1; i < path.length; i++) {
+    ctx.lineTo(path[i].x, path[i].y);
+  }
+  ctx.stroke();
+
+  ctx.strokeStyle = "#0ea5e9";
+  ctx.lineWidth = 18;
+  ctx.beginPath();
+  ctx.moveTo(path[0].x, path[0].y);
+  for (let i = 1; i < path.length; i++) {
+    ctx.lineTo(path[i].x, path[i].y);
+  }
+  ctx.stroke();
+
+  ctx.fillStyle = "#ef4444";
+  const base = path[path.length - 1];
+  ctx.beginPath();
+  ctx.arc(base.x, base.y, 26, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = "#22c55e";
+  const start = path[0];
+  ctx.beginPath();
+  ctx.arc(start.x, start.y, 22, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawUnits() {
+  for (const unit of units) {
+    if (!unit.alive) continue;
+    ctx.save();
+    ctx.fillStyle = unit.color;
+    ctx.beginPath();
+    ctx.arc(unit.position.x, unit.position.y, unit.radius, 0, Math.PI * 2);
+    ctx.fill();
+
+    // health bar
+    ctx.fillStyle = "rgba(15, 23, 42, 0.9)";
+    ctx.fillRect(
+      unit.position.x - unit.radius,
+      unit.position.y - unit.radius - 8,
+      unit.radius * 2,
+      4
+    );
+    const healthWidth = (unit.health / unit.maxHealth) * unit.radius * 2;
+    ctx.fillStyle = "#4ade80";
+    ctx.fillRect(
+      unit.position.x - unit.radius,
+      unit.position.y - unit.radius - 8,
+      healthWidth,
+      4
+    );
+    ctx.restore();
+  }
+}
+
+function drawTowers() {
+  for (const tower of towers) {
+    tower.draw();
+  }
+}
+
+function drawProjectiles() {
+  for (const projectile of projectiles) {
+    projectile.draw();
+  }
+}
+
+let lastTime = performance.now();
+
+function gameLoop(time) {
+  const dt = Math.min((time - lastTime) / 1000, 0.1);
+  lastTime = time;
+
+  update(dt);
+  drawBackground();
+  drawTowers();
+  drawUnits();
+  drawProjectiles();
+
+  if (!gameOver) {
+    requestAnimationFrame(gameLoop);
+  } else {
+    drawOverlay();
+  }
+}
+
+function drawOverlay() {
+  ctx.save();
+  ctx.fillStyle = "rgba(15, 23, 42, 0.65)";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = "#f8fafc";
+  ctx.font = "bold 36px 'Segoe UI', sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText(
+    escapedCount >= TARGET_ESCAPED ? "Victory!" : "Defeat",
+    canvas.width / 2,
+    canvas.height / 2 - 10
+  );
+  ctx.font = "20px 'Segoe UI', sans-serif";
+  ctx.fillText(
+    escapedCount >= TARGET_ESCAPED
+      ? "Your raiders breached the portal."
+      : "The defense grid held strong this time.",
+    canvas.width / 2,
+    canvas.height / 2 + 24
+  );
+  ctx.restore();
+}
+
+unitButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const type = button.dataset.unit;
+    spawnUnit(type);
+  });
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.repeat) return;
+  if (event.key === "1") spawnUnit("scout");
+  if (event.key === "2") spawnUnit("bruiser");
+  if (event.key === "3") spawnUnit("tank");
+});
+
+createTowers();
+commandPointsEl.textContent = commandPoints.toString();
+requestAnimationFrame(gameLoop);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Reverse Tower Defense</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="hud">
+      <h1>Reverse Tower Defense</h1>
+      <p>
+        Deploy raiding parties that can break through the automated defenses. If
+        twenty units reach the escape portal, you win!
+      </p>
+    </header>
+
+    <main class="layout">
+      <section class="panel">
+        <h2>Command Console</h2>
+        <p class="resources">
+          <strong>Command Points:</strong>
+          <span id="commandPoints" aria-live="polite">0</span>
+        </p>
+        <div class="buttons">
+          <button data-unit="scout" aria-label="Deploy Scout (costs 30)">
+            Deploy Scout
+            <small>Cost: 30</small>
+          </button>
+          <button data-unit="bruiser" aria-label="Deploy Bruiser (costs 55)">
+            Deploy Bruiser
+            <small>Cost: 55</small>
+          </button>
+          <button data-unit="tank" aria-label="Deploy Tank (costs 90)">
+            Deploy Tank
+            <small>Cost: 90</small>
+          </button>
+        </div>
+        <p class="tip">Command points regenerate automatically.</p>
+        <div class="objectives">
+          <p>
+            <strong>Raiders escaped:</strong>
+            <span id="escaped" aria-live="polite">0</span> / 20
+          </p>
+          <p id="status" role="status" aria-live="polite"></p>
+        </div>
+      </section>
+      <section class="playfield">
+        <canvas
+          id="game"
+          width="900"
+          height="600"
+          role="img"
+          aria-label="Game board showing the enemy base, path, and defensive towers"
+        ></canvas>
+      </section>
+    </main>
+
+    <footer class="hud">
+      <p>
+        Tip: Scouts are quick distractions. Bruisers soak shots. Tanks are slow
+        but almost unstoppable.
+      </p>
+    </footer>
+
+    <script src="game.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,141 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+  background-color: #10131a;
+  color: #f1f5f9;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+h1,
+ h2 {
+  margin: 0 0 0.4rem;
+  font-weight: 600;
+}
+
+p {
+  margin: 0.4rem 0;
+}
+
+main.layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 1rem;
+  padding: 1rem;
+  flex: 1;
+  box-sizing: border-box;
+}
+
+.hud,
+.panel {
+  background: rgba(15, 23, 42, 0.9);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1rem;
+  box-shadow: 0 0 15px rgba(15, 23, 42, 0.5);
+}
+
+.panel {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+}
+
+.hud {
+  text-align: center;
+}
+
+.resources strong {
+  display: inline-block;
+  min-width: 150px;
+}
+
+.buttons {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+button {
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  color: white;
+  border: none;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(14, 165, 233, 0.25);
+}
+
+button small {
+  font-weight: 400;
+  opacity: 0.8;
+}
+
+.playfield {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: radial-gradient(circle at 20% 20%, #1e293b, #0f172a 65%);
+}
+
+.tip {
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.objectives {
+  margin-top: 1rem;
+  background: rgba(15, 23, 42, 0.65);
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+}
+
+footer {
+  font-size: 0.95rem;
+}
+
+@media (max-width: 900px) {
+  main.layout {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    position: relative;
+    top: auto;
+  }
+}
+
+#status {
+  min-height: 1.2rem;
+  opacity: 0.65;
+  transition: opacity 0.3s ease;
+}
+
+#status.visible {
+  opacity: 1;
+  color: #38bdf8;
+}


### PR DESCRIPTION
## Summary
- add a responsive control panel and canvas playfield for the reverse tower defense experience
- implement unit, tower, and projectile systems with a victory condition in vanilla JavaScript
- document how to run and deploy the GitHub Pages friendly build

## Testing
- Manual validation in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dccacdb6f08325bec0d65dfc5fb003