### PR TITLE
Add unit stat displays to command console

### DIFF
--- a/game.js
+++ b/game.js
@@ -20,10 +20,7 @@ const restartButton =
     ? document.getElementById("restartButton")
     : null;
 
-const unitButtons =
-  typeof document !== "undefined"
-    ? Array.from(document.querySelectorAll("button[data-unit]"))
-    : [];
+let unitButtons = [];
 
 const TARGET_ESCAPED = 20;
 const BASE_POINTS = 60;
@@ -54,6 +51,7 @@ const unitTypes = {
     radius: 10,
     color: "#22d3ee",
     cost: 30,
+    role: "Swift distraction that draws tower fire.",
   },
   bruiser: {
     name: "Bruiser",
@@ -62,6 +60,7 @@ const unitTypes = {
     radius: 12,
     color: "#f97316",
     cost: 55,
+    role: "Front-line brawler built to soak damage.",
   },
   tank: {
     name: "Tank",
@@ -70,8 +69,75 @@ const unitTypes = {
     radius: 14,
     color: "#a855f7",
     cost: 90,
+    role: "Siege engine that shrugs off focused fire.",
   },
 };
+
+function buildUnitButtons(container) {
+  const buttons = [];
+  container.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+
+  Object.entries(unitTypes).forEach(([key, unit]) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.dataset.unit = key;
+    const ariaLabel = `Deploy ${unit.name} (Cost ${unit.cost}, Speed ${unit.speed}, Health ${unit.health}, Role ${unit.role})`;
+    button.setAttribute("aria-label", ariaLabel);
+    button.title = `${unit.name}\nCost: ${unit.cost}\nSpeed: ${unit.speed}\nHealth: ${unit.health}\nRole: ${unit.role}`;
+
+    const name = document.createElement("span");
+    name.className = "unit-name";
+    name.textContent = `Deploy ${unit.name}`;
+    button.appendChild(name);
+
+    const cost = document.createElement("small");
+    cost.className = "unit-cost";
+    cost.textContent = `Cost: ${unit.cost}`;
+    button.appendChild(cost);
+
+    const stats = document.createElement("span");
+    stats.className = "unit-stats";
+
+    const speedStat = document.createElement("span");
+    speedStat.className = "stat";
+    speedStat.append("Speed ");
+    const speedValue = document.createElement("strong");
+    speedValue.textContent = unit.speed.toString();
+    speedStat.appendChild(speedValue);
+    stats.appendChild(speedStat);
+
+    const healthStat = document.createElement("span");
+    healthStat.className = "stat";
+    healthStat.append("Health ");
+    const healthValue = document.createElement("strong");
+    healthValue.textContent = unit.health.toString();
+    healthStat.appendChild(healthValue);
+    stats.appendChild(healthStat);
+
+    button.appendChild(stats);
+
+    const role = document.createElement("span");
+    role.className = "unit-role";
+    role.textContent = `Role: ${unit.role}`;
+    button.appendChild(role);
+
+    fragment.appendChild(button);
+    buttons.push(button);
+  });
+
+  container.appendChild(fragment);
+  return buttons;
+}
+
+if (typeof document !== "undefined") {
+  const buttonContainer = document.querySelector(".buttons");
+  if (buttonContainer) {
+    unitButtons = buildUnitButtons(buttonContainer);
+  } else {
+    unitButtons = Array.from(document.querySelectorAll("button[data-unit]"));
+  }
+}
 
 class Unit {
   constructor(type) {

--- a/index.html
+++ b/index.html
@@ -22,20 +22,7 @@
           <strong>Command Points:</strong>
           <span id="commandPoints" aria-live="polite">0</span>
         </p>
-        <div class="buttons">
-          <button data-unit="scout" aria-label="Deploy Scout (costs 30)">
-            Deploy Scout
-            <small>Cost: 30</small>
-          </button>
-          <button data-unit="bruiser" aria-label="Deploy Bruiser (costs 55)">
-            Deploy Bruiser
-            <small>Cost: 55</small>
-          </button>
-          <button data-unit="tank" aria-label="Deploy Tank (costs 90)">
-            Deploy Tank
-            <small>Cost: 90</small>
-          </button>
-        </div>
+        <div class="buttons" aria-label="Unit deployment options"></div>
         <p class="tip">Command points regenerate automatically.</p>
         <div class="objectives">
           <p>

--- a/style.css
+++ b/style.css
@@ -65,6 +65,10 @@ main.layout {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.buttons button {
+  gap: 0.4rem;
+}
+
 button {
   background: linear-gradient(135deg, #0ea5e9, #6366f1);
   color: white;
@@ -93,6 +97,38 @@ button[hidden] {
 button small {
   font-weight: 400;
   opacity: 0.8;
+}
+
+.buttons .unit-name {
+  font-size: 1.05rem;
+}
+
+.buttons .unit-cost {
+  font-size: 0.82rem;
+}
+
+.buttons .unit-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: rgba(241, 245, 249, 0.82);
+}
+
+.buttons .unit-stats .stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+.buttons .unit-stats strong {
+  font-size: 0.82rem;
+}
+
+.buttons .unit-role {
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.95);
+  letter-spacing: 0.01em;
 }
 
 .playfield {
@@ -197,6 +233,15 @@ footer {
   button {
     font-size: 0.95rem;
     padding: 0.65rem 0.85rem;
+  }
+
+  .buttons .unit-name {
+    font-size: 1rem;
+  }
+
+  .buttons .unit-stats,
+  .buttons .unit-role {
+    font-size: 0.75rem;
   }
 
   .playfield {


### PR DESCRIPTION
## Summary
- render the command console buttons from `unitTypes` so stat changes stay in sync with the UI
- show each unit’s speed, health, and role in the deployment buttons with accessible labels/tooltips
- tune command console button styling for the denser stat layout and ensure it remains readable on smaller screens

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dd4fcc64d483259bd6749cdb525a7f