### PR TITLE
Add difficulty presets and selection UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
     <main class="layout">
       <section class="panel">
         <h2>Command Console</h2>
+        <div class="difficulty-control">
+          <label for="difficulty">Difficulty</label>
+          <select id="difficulty" aria-label="Select difficulty"></select>
+        </div>
         <p class="resources">
           <strong>Command Points:</strong>
           <span id="commandPoints" aria-live="polite">0</span>
@@ -27,7 +31,9 @@
         <div class="objectives">
           <p>
             <strong>Raiders escaped:</strong>
-            <span id="escaped" aria-live="polite">0</span> / 20
+            <span id="escaped" aria-live="polite">0</span>
+            /
+            <span id="targetTotal">20</span>
           </p>
           <p id="status" role="status" aria-live="polite"></p>
         </div>

--- a/style.css
+++ b/style.css
@@ -58,6 +58,33 @@ main.layout {
   min-width: 150px;
 }
 
+.difficulty-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.difficulty-control label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.difficulty-control select {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.difficulty-control select:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.65);
+  outline-offset: 2px;
+}
+
 .buttons {
   display: grid;
   gap: 0.75rem;


### PR DESCRIPTION
## Summary
- add difficulty presets that define command point economy, escape goals, and tower layouts
- hook game initialization and resets into the selected preset and expose a difficulty picker in the HUD

## Testing
- npm test *(fails: jest not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5ff1d35c832598fc7fa58377d72b