### PR TITLE
Add automatic Jest install for npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Reverse Tower Defense browser game",
   "private": true,
   "scripts": {
-    "test": "jest"
+    "test": "node scripts/run-jest.js"
   },
   "devDependencies": {
     "jest": "29.7.0",

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+
+function resolveJestBin() {
+  try {
+    return require.resolve("jest/bin/jest");
+  } catch (error) {
+    if (error.code === "MODULE_NOT_FOUND") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function installDependencies() {
+  const install = spawnSync("npm", ["install"], {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (install.status !== 0) {
+    process.exit(install.status ?? 1);
+  }
+}
+
+let jestBin = resolveJestBin();
+if (!jestBin) {
+  console.log("Jest was not found. Installing project dependencies...");
+  installDependencies();
+  jestBin = resolveJestBin();
+  if (!jestBin) {
+    console.error(
+      "Jest could not be resolved even after installing dependencies."
+    );
+    process.exit(1);
+  }
+}
+
+const result = spawnSync(process.execPath, [jestBin, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- add a helper script that resolves the local Jest binary and installs dependencies when it is missing
- update the npm test script to invoke the helper so tests run even before dependencies are installed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd62d0df908325b2e7c82a44be1a32