### PR TITLE
Improve layout responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -19,8 +19,8 @@
 body {
   margin: 0;
   min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
   position: relative;
   overflow-x: hidden;
   background: radial-gradient(circle at 20% 0%, rgba(86, 155, 112, 0.3), transparent 55%),
@@ -82,13 +82,13 @@ p {
 
 main.layout {
   display: grid;
-  grid-template-columns: minmax(270px, 320px) minmax(0, 1fr);
-  gap: 1.5rem;
-  padding: 1.75rem;
-  flex: 1;
+  grid-template-columns: clamp(260px, 27vw, 340px) minmax(0, 1fr);
+  align-items: center;
+  gap: clamp(1rem, 2.5vw, 2rem);
+  padding: clamp(1rem, 2.3vw, 1.75rem);
   box-sizing: border-box;
-  width: min(1180px, 100%);
-  margin: 0 auto 1.5rem;
+  width: min(1240px, 94vw);
+  margin: 0 auto;
 }
 
 .hud,
@@ -115,7 +115,7 @@ main.layout {
 .panel {
   background: var(--surface-panel);
   position: sticky;
-  top: 1.25rem;
+  top: clamp(0.75rem, 2vh, 1.5rem);
   align-self: start;
   backdrop-filter: blur(10px);
 }
@@ -133,7 +133,7 @@ main.layout {
   text-align: center;
   margin-inline: auto;
   width: min(1040px, calc(100% - 2rem));
-  padding-block: 1.4rem;
+  padding-block: clamp(1rem, 2.5vh, 1.4rem);
 }
 
 .hud p {
@@ -295,6 +295,8 @@ button small {
   box-shadow: 0 26px 48px rgba(5, 16, 9, 0.6);
   background: radial-gradient(circle at 30% 10%, rgba(144, 214, 171, 0.12), transparent 60%),
     radial-gradient(circle at 70% 90%, rgba(255, 215, 122, 0.08), transparent 65%);
+  width: min(100%, clamp(620px, 70vw, 1080px));
+  justify-self: center;
 }
 
 canvas {
@@ -423,21 +425,39 @@ button:focus-visible::after {
   }
 }
 
+@media (max-width: 1200px) {
+  main.layout {
+    grid-template-columns: clamp(240px, 32vw, 320px) minmax(0, 1fr);
+    width: min(1100px, 96vw);
+  }
+
+  .playfield {
+    width: min(100%, clamp(560px, 68vw, 980px));
+  }
+}
+
 @media (max-width: 900px) {
   main.layout {
     grid-template-columns: 1fr;
-    padding: 1.25rem;
-    width: min(720px, 100%);
+    grid-template-rows: auto auto;
+    align-items: stretch;
+    padding: clamp(0.9rem, 2.5vw, 1.25rem);
+    width: min(760px, 94vw);
   }
 
   .panel {
     position: relative;
     top: auto;
     order: 2;
+    margin-bottom: clamp(0.75rem, 2vw, 1.25rem);
   }
 
   .hud {
-    width: calc(100% - 2rem);
+    width: min(760px, calc(100% - 2rem));
+  }
+
+  .playfield {
+    width: min(100%, clamp(520px, 84vw, 920px));
   }
 }
 
@@ -453,9 +473,9 @@ button:focus-visible::after {
   }
 
   main.layout {
-    padding: 1rem;
-    gap: 1rem;
-    width: calc(100% - 1rem);
+    padding: 0.9rem;
+    gap: 0.9rem;
+    width: 100%;
   }
 
   .buttons {
@@ -478,5 +498,7 @@ button:focus-visible::after {
 
   .playfield {
     border-radius: 12px;
+    width: 100%;
+    max-width: none;
   }
 }


### PR DESCRIPTION
## Summary
- convert the page shell to a CSS grid layout so the header, playfield, and footer fit comfortably on full HD screens
- tune the playfield sizing and sticky dispatch panel spacing to keep the game area prominent without forcing scroll
- refresh the responsive breakpoints to stack content cleanly on tablets and phones

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de426acf448325aa34cb1d8832ff99