### PR TITLE
Condense canopy dispatch layout

### DIFF
--- a/game.js
+++ b/game.js
@@ -190,50 +190,72 @@ function buildUnitButtons(container) {
   const fragment = document.createDocumentFragment();
 
   Object.entries(unitTypes).forEach(([key, unit]) => {
+    const option = document.createElement("div");
+    option.className = "unit-option";
+
     const button = document.createElement("button");
     button.type = "button";
     button.dataset.unit = key;
-    const ariaLabel = `Deploy ${unit.name} (Cost ${unit.cost}, Speed ${unit.speed}, Health ${unit.health}, Role ${unit.role})`;
-    button.setAttribute("aria-label", ariaLabel);
-    button.title = `${unit.name}\nCost: ${unit.cost}\nSpeed: ${unit.speed}\nHealth: ${unit.health}\nRole: ${unit.role}`;
+    button.className = "unit-button";
+    button.setAttribute("aria-label", `Deploy ${unit.name}`);
+    const tooltipId = `unit-${key}-details`;
+    button.setAttribute("aria-describedby", tooltipId);
 
-    const name = document.createElement("span");
-    name.className = "unit-name";
-    name.textContent = `Deploy ${unit.name}`;
-    button.appendChild(name);
+    const icon = document.createElement("span");
+    icon.className = `unit-icon unit-icon--${key}`;
+    icon.setAttribute("aria-hidden", "true");
+    button.appendChild(icon);
 
-    const cost = document.createElement("small");
-    cost.className = "unit-cost";
-    cost.textContent = `Cost: ${unit.cost}`;
-    button.appendChild(cost);
+    const label = document.createElement("span");
+    label.className = "unit-label";
+    label.textContent = unit.name;
+    button.appendChild(label);
 
-    const stats = document.createElement("span");
-    stats.className = "unit-stats";
+    option.appendChild(button);
 
-    const speedStat = document.createElement("span");
-    speedStat.className = "stat";
-    speedStat.append("Speed ");
-    const speedValue = document.createElement("strong");
-    speedValue.textContent = unit.speed.toString();
-    speedStat.appendChild(speedValue);
-    stats.appendChild(speedStat);
+    const tooltip = document.createElement("div");
+    tooltip.className = "unit-tooltip";
+    tooltip.id = tooltipId;
+    tooltip.setAttribute("role", "tooltip");
 
-    const healthStat = document.createElement("span");
-    healthStat.className = "stat";
-    healthStat.append("Health ");
-    const healthValue = document.createElement("strong");
-    healthValue.textContent = unit.health.toString();
-    healthStat.appendChild(healthValue);
-    stats.appendChild(healthStat);
+    const tooltipTitle = document.createElement("h3");
+    tooltipTitle.className = "unit-tooltip-title";
+    tooltipTitle.textContent = unit.name;
+    tooltip.appendChild(tooltipTitle);
 
-    button.appendChild(stats);
-
-    const role = document.createElement("span");
+    const role = document.createElement("p");
     role.className = "unit-role";
-    role.textContent = `Role: ${unit.role}`;
-    button.appendChild(role);
+    role.textContent = unit.role;
+    tooltip.appendChild(role);
 
-    fragment.appendChild(button);
+    const statList = document.createElement("dl");
+    statList.className = "unit-stats";
+
+    const stats = [
+      ["Cost", unit.cost],
+      ["Speed", unit.speed],
+      ["Health", unit.health],
+    ];
+
+    stats.forEach(([labelText, value]) => {
+      const item = document.createElement("div");
+      item.className = "unit-stat";
+
+      const term = document.createElement("dt");
+      term.textContent = labelText;
+
+      const description = document.createElement("dd");
+      description.textContent = value.toString();
+
+      item.appendChild(term);
+      item.appendChild(description);
+      statList.appendChild(item);
+    });
+
+    tooltip.appendChild(statList);
+    option.appendChild(tooltip);
+
+    fragment.appendChild(option);
     buttons.push(button);
   });
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
   </head>
   <body>
     <header class="hud">
-      <span class="hud-badge" aria-hidden="true">Reverse TD</span>
       <h1>Vine-Trellis Lynx Cooperative</h1>
       <p>
         Guide the cooperative's scouts, wardens, and guardians through the
@@ -25,31 +24,71 @@
     </header>
 
     <main class="layout">
-      <section class="panel">
-        <h2>Canopy Dispatch</h2>
-        <div class="difficulty-control">
-          <label for="difficulty">Path Intensity</label>
-          <select id="difficulty" aria-label="Select path intensity"></select>
+      <section class="dispatch">
+        <header class="dispatch-heading">
+          <div>
+            <h2>Canopy Dispatch</h2>
+            <p class="dispatch-tagline">Quick directives for the caravan core.</p>
+          </div>
+        </header>
+        <div class="dispatch-body">
+          <div class="dispatch-controls">
+            <div class="difficulty-control">
+              <label for="difficulty">Path Intensity</label>
+              <select id="difficulty" aria-label="Select path intensity"></select>
+            </div>
+            <p
+              id="difficultyDescription"
+              class="difficulty-description"
+              aria-live="polite"
+            ></p>
+          </div>
+          <div class="dispatch-summary">
+            <article class="stat-card stat-card--points">
+              <div class="stat-card-header">
+                <span>Harvest Points</span>
+                <span class="tooltip">
+                  <button
+                    class="tooltip-button"
+                    type="button"
+                    aria-describedby="harvestTip"
+                    aria-label="Harvest points tip"
+                  >
+                    i
+                  </button>
+                  <span class="tooltip-bubble" role="tooltip" id="harvestTip">
+                    Harvest points bloom back over time.
+                  </span>
+                </span>
+              </div>
+              <span class="stat-card-value" id="commandPoints" aria-live="polite"
+                >0</span
+              >
+            </article>
+            <article class="stat-card stat-card--families">
+              <span class="stat-card-header">Lynx families sheltered</span>
+              <div class="stat-card-value stat-card-value--fraction">
+                <span id="escaped" aria-live="polite">0</span>
+                <span class="stat-card-divider" aria-hidden="true">/</span>
+                <span id="targetTotal">20</span>
+              </div>
+            </article>
+            <article class="stat-card stat-card--status">
+              <span class="stat-card-header">Dispatch status</span>
+              <p id="status" role="status" aria-live="polite"></p>
+            </article>
+          </div>
         </div>
-        <p
-          id="difficultyDescription"
-          class="difficulty-description"
-          aria-live="polite"
-        ></p>
-        <p class="resources">
-          <strong>Harvest Points:</strong>
-          <span id="commandPoints" aria-live="polite">0</span>
-        </p>
-        <div class="buttons" aria-label="Forage caravan options"></div>
-        <p class="tip">Harvest points bloom back over time.</p>
-        <div class="objectives">
-          <p>
-            <strong>Lynx families sheltered:</strong>
-            <span id="escaped" aria-live="polite">0</span>
-            /
-            <span id="targetTotal">20</span>
-          </p>
-          <p id="status" role="status" aria-live="polite"></p>
+        <div class="dispatch-buttons">
+          <div class="unit-toolbar-header">
+            <h3 class="unit-toolbar-heading">Caravan Units</h3>
+            <p class="unit-toolbar-caption">Hover or focus to study each role.</p>
+          </div>
+          <div
+            class="buttons unit-toolbar"
+            role="toolbar"
+            aria-label="Caravan unit roster"
+          ></div>
         </div>
       </section>
       <section class="playfield">
@@ -65,13 +104,6 @@
         </button>
       </section>
     </main>
-
-    <footer class="hud">
-      <p>
-        Tip: Seed Runners draw tower focus. Lynx Wardens hold the line. Grove
-        Sentinels are slow but nearly unshakeable.
-      </p>
-    </footer>
 
     <script src="game.js"></script>
   </body>

--- a/style.css
+++ b/style.css
@@ -20,7 +20,7 @@ body {
   margin: 0;
   min-height: 100vh;
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto 1fr;
   position: relative;
   overflow-x: hidden;
   background: radial-gradient(circle at 20% 0%, rgba(86, 155, 112, 0.3), transparent 55%),
@@ -81,18 +81,17 @@ p {
 }
 
 main.layout {
-  display: grid;
-  grid-template-columns: clamp(260px, 27vw, 340px) minmax(0, 1fr);
-  align-items: center;
-  gap: clamp(1rem, 2.5vw, 2rem);
-  padding: clamp(1rem, 2.3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.2rem, 3vw, 2.4rem);
+  padding: clamp(1.1rem, 2.6vw, 2rem);
   box-sizing: border-box;
-  width: min(1240px, 94vw);
+  width: min(1280px, 96vw);
   margin: 0 auto;
 }
 
 .hud,
-.panel {
+.dispatch {
   background: var(--surface-elevated);
   padding: 1.15rem 1.4rem;
   border: 1px solid rgba(164, 214, 185, 0.25);
@@ -103,7 +102,7 @@ main.layout {
 }
 
 .hud::before,
-.panel::before {
+.dispatch::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -112,15 +111,16 @@ main.layout {
   pointer-events: none;
 }
 
-.panel {
+.dispatch {
   background: var(--surface-panel);
-  position: sticky;
-  top: clamp(0.75rem, 2vh, 1.5rem);
-  align-self: start;
   backdrop-filter: blur(10px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(0.8rem, 2.4vw, 1.4rem);
+  padding: clamp(0.9rem, 2.4vw, 1.4rem);
 }
 
-.panel::after {
+.dispatch::after {
   content: "";
   position: absolute;
   inset: 1px;
@@ -143,34 +143,229 @@ main.layout {
   margin-inline: auto;
 }
 
-.hud-badge {
+.dispatch-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid rgba(116, 184, 143, 0.22);
+}
+
+.dispatch-heading h2 {
+  margin-bottom: 0.1rem;
+}
+
+.dispatch-tagline {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(216, 241, 223, 0.72);
+}
+
+.dispatch-body {
+  display: grid;
+  gap: clamp(0.8rem, 2vw, 1.4rem);
+}
+
+.dispatch-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 16px;
+  background: rgba(7, 28, 17, 0.78);
+  border: 1px solid rgba(136, 214, 165, 0.28);
+  box-shadow: inset 0 1px 0 rgba(162, 238, 192, 0.16),
+    0 16px 30px rgba(6, 18, 12, 0.45);
+}
+
+.dispatch-summary {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  align-content: start;
+}
+
+.stat-card {
+  background: linear-gradient(160deg, rgba(14, 44, 27, 0.9), rgba(5, 21, 12, 0.92));
+  border-radius: 16px;
+  border: 1px solid rgba(144, 214, 170, 0.28);
+  padding: 0.75rem 0.9rem;
+  display: grid;
+  gap: 0.45rem;
+  box-shadow: inset 0 1px 0 rgba(164, 236, 199, 0.12),
+    0 18px 28px rgba(5, 15, 10, 0.45);
+}
+
+.stat-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(214, 243, 224, 0.76);
+}
+
+.stat-card-value {
+  font-size: clamp(1.2rem, 2.6vw, 1.75rem);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: #f3ffef;
+}
+
+.stat-card-value--fraction {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-size: 1.2rem;
+}
+
+.stat-card-divider {
+  color: rgba(219, 245, 228, 0.6);
+  font-weight: 500;
+}
+
+.stat-card--status {
+  min-height: 92px;
+}
+
+.stat-card--status p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 249, 231, 0.85);
+}
+
+.dispatch-buttons {
+  display: grid;
+  gap: 0.6rem;
+  background: rgba(6, 24, 14, 0.78);
+  border-radius: 16px;
+  border: 1px solid rgba(140, 212, 168, 0.22);
+  padding: 0.7rem 0.85rem 0.8rem;
+  box-shadow: inset 0 1px 0 rgba(148, 232, 189, 0.12),
+    0 16px 26px rgba(5, 14, 9, 0.48);
+}
+
+.unit-toolbar-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.unit-toolbar-heading {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.unit-toolbar-caption {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(214, 243, 224, 0.64);
+}
+
+.dispatch-buttons .unit-toolbar-heading {
+  color: #effff4;
+}
+
+.tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.tooltip-button {
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 50%;
+  border: 1px solid rgba(151, 236, 183, 0.55);
+  background: rgba(25, 63, 38, 0.75);
+  color: var(--accent-tertiary);
+  font-size: 0.9rem;
+  font-weight: 600;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--accent-tertiary);
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  background: rgba(56, 135, 91, 0.45);
-  border: 1px solid rgba(157, 248, 223, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(71, 160, 114, 0.45);
-  margin-bottom: 0.9rem;
-  animation: shimmer 6s ease-in-out infinite;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.resources strong {
-  display: inline-block;
-  min-width: 170px;
+.tooltip-button:hover,
+.tooltip-button:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(38, 92, 55, 0.85);
+  box-shadow: 0 10px 18px rgba(6, 24, 15, 0.4);
+}
+
+.tooltip-button:focus-visible {
+  outline: 2px solid rgba(148, 255, 199, 0.8);
+  outline-offset: 2px;
+}
+
+.tooltip-bubble {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  left: 50%;
+  transform: translate(-50%, -8px);
+  background: rgba(7, 30, 18, 0.94);
+  color: rgba(226, 246, 226, 0.88);
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(154, 214, 174, 0.4);
+  box-shadow: 0 16px 30px rgba(4, 12, 8, 0.45);
+  max-width: 240px;
+  width: max-content;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  line-height: 1.35;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.tooltip::after {
+  content: "";
+  position: absolute;
+  top: calc(100% + 0.2rem);
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid rgba(7, 30, 18, 0.94);
+  transform: translateX(-50%);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.tooltip:hover .tooltip-bubble,
+.tooltip:focus-within .tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+.tooltip:hover::after,
+.tooltip:focus-within::after {
+  opacity: 1;
+  visibility: visible;
 }
 
 .difficulty-control {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  margin: 0.5rem 0 0.75rem;
+  margin: 0;
 }
 
 .difficulty-control label {
@@ -196,93 +391,256 @@ main.layout {
 }
 
 .difficulty-description {
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   color: rgba(231, 249, 235, 0.78);
-  margin: 0.2rem 0 0.8rem;
-  line-height: 1.4;
-  padding: 0.6rem 0.75rem;
+  margin: 0.15rem 0 0;
+  line-height: 1.35;
+  padding: 0.55rem 0.7rem;
   background: rgba(11, 37, 23, 0.7);
   border-radius: 12px;
   border: 1px solid rgba(140, 205, 166, 0.25);
   box-shadow: inset 0 0 0 1px rgba(54, 119, 82, 0.2);
 }
 
-.buttons {
-  display: grid;
-  gap: 0.75rem;
-  margin: 1rem 0;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+.unit-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.55rem, 1.6vw, 0.85rem);
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: clamp(0.45rem, 1.4vw, 0.65rem);
+  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(14, 44, 28, 0.85), rgba(6, 20, 12, 0.9));
+  border: 1px solid rgba(137, 205, 163, 0.26);
+  box-shadow: inset 0 1px 0 rgba(174, 239, 198, 0.14), 0 12px 24px rgba(6, 18, 12, 0.48);
 }
 
-.buttons button {
-  gap: 0.4rem;
+.unit-option {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-width: clamp(160px, 32vw, 220px);
 }
 
 button {
-  background: linear-gradient(150deg, #2f9a62 0%, #7acb82 45%, #b4fce1 100%);
-  color: #042113;
-  border: none;
-  border-radius: 16px;
-  padding: 0.85rem 1.1rem;
-  font-size: 1rem;
-  font-weight: 600;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  font: inherit;
   cursor: pointer;
+  color: inherit;
+  background: none;
+  border: none;
+}
+
+.unit-button {
+  background: linear-gradient(150deg, rgba(46, 112, 73, 0.72), rgba(22, 59, 38, 0.88));
+  border: 1px solid rgba(148, 224, 172, 0.35);
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.65rem;
+  color: #f0fff4;
+  text-transform: none;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 20px rgba(5, 16, 10, 0.52);
   transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
-  box-shadow: 0 10px 22px rgba(21, 71, 43, 0.38);
+  width: 100%;
+  min-height: 56px;
   position: relative;
   overflow: hidden;
 }
 
-button:hover,
-button:focus-visible {
-  transform: translateY(-3px) scale(1.01);
-  box-shadow: 0 20px 32px rgba(36, 111, 68, 0.5);
-  filter: brightness(1.05);
+.unit-button:hover,
+.unit-button:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 26px rgba(10, 28, 18, 0.6);
+  filter: brightness(1.06);
+  outline: none;
 }
 
-button[hidden] {
-  display: none !important;
+.unit-button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(116, 210, 165, 0.45),
+    0 18px 28px rgba(10, 28, 18, 0.6);
 }
 
-button small {
-  font-weight: 400;
-  opacity: 0.85;
-  color: rgba(8, 29, 16, 0.9);
+.unit-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: left;
+  color: #f4ffed;
+  text-shadow: 0 1px 0 rgba(6, 19, 12, 0.6);
+  white-space: nowrap;
 }
 
-.buttons .unit-name {
-  font-size: 1.08rem;
+.unit-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  position: relative;
+  background: rgba(10, 30, 19, 0.65);
+  border: 1px solid rgba(136, 214, 165, 0.4);
+  box-shadow: inset 0 0 12px rgba(24, 70, 44, 0.55), 0 5px 12px rgba(4, 12, 8, 0.55);
 }
 
-.buttons .unit-cost {
-  font-size: 0.82rem;
+.unit-icon::before,
+.unit-icon::after {
+  content: "";
+  position: absolute;
 }
 
-.buttons .unit-stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  font-size: 0.78rem;
-  color: rgba(6, 32, 19, 0.85);
+.unit-icon--scout::before {
+  width: 32px;
+  height: 32px;
+  border-radius: 58% 42% 60% 40%;
+  background: radial-gradient(circle at 30% 30%, #fef3c7, #facc15 62%, #d97706);
+  transform: rotate(-24deg);
+  box-shadow: 0 3px 8px rgba(145, 90, 15, 0.35);
 }
 
-.buttons .unit-stats .stat {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.25rem;
+.unit-icon--scout::after {
+  width: 12px;
+  height: 14px;
+  border-radius: 50% 0 55% 10%;
+  background: rgba(87, 140, 89, 0.82);
+  top: 56%;
+  left: 52%;
+  transform: translate(-50%, -50%) rotate(34deg);
+  box-shadow: 0 1px 3px rgba(24, 63, 36, 0.4);
 }
 
-.buttons .unit-stats strong {
-  font-size: 0.82rem;
+.unit-icon--bruiser::before {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px 28px 32px 12px;
+  background: linear-gradient(140deg, #34d399 10%, #059669 85%);
+  transform: rotate(18deg);
+  box-shadow: 0 3px 9px rgba(4, 76, 49, 0.38);
 }
 
-.buttons .unit-role {
-  font-size: 0.78rem;
-  color: rgba(9, 38, 20, 0.82);
+.unit-icon--bruiser::after {
+  width: 18px;
+  height: 18px;
+  border-radius: 45% 55% 45% 55%;
+  background: rgba(214, 255, 231, 0.88);
+  border: 2px solid rgba(22, 80, 51, 0.7);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-18deg);
+  box-shadow: 0 2px 6px rgba(11, 60, 39, 0.38);
+}
+
+.unit-icon--tank::before {
+  width: 38px;
+  height: 44px;
+  border-radius: 18px 18px 12px 12px / 22px 22px 18px 18px;
+  background: linear-gradient(160deg, #7c3aed 15%, #a855f7 85%);
+  box-shadow: 0 4px 10px rgba(43, 14, 89, 0.4);
+}
+
+.unit-icon--tank::after {
+  width: 18px;
+  height: 24px;
+  border-radius: 50% 50% 40% 40%;
+  background: rgba(236, 233, 254, 0.92);
+  top: 34%;
+  left: 50%;
+  transform: translate(-50%, -20%);
+  box-shadow: 0 2px 6px rgba(70, 38, 128, 0.38);
+}
+
+.unit-tooltip {
+  position: absolute;
+  bottom: calc(100% + 0.75rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(8px);
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  background: var(--surface-elevated);
+  border: 1px solid rgba(160, 228, 187, 0.35);
+  box-shadow: 0 18px 32px rgba(4, 15, 8, 0.55);
+  width: min(240px, 65vw);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  z-index: 10;
+  text-align: left;
+}
+
+.unit-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 8px 10px 0 10px;
+  border-style: solid;
+  border-color: rgba(160, 228, 187, 0.35) transparent transparent transparent;
+}
+
+.unit-tooltip::before {
+  content: "";
+  position: absolute;
+  top: calc(100% - 1px);
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 7px 9px 0 9px;
+  border-style: solid;
+  border-color: var(--surface-elevated) transparent transparent transparent;
+  z-index: 1;
+}
+
+.unit-option:hover .unit-tooltip,
+.unit-option:focus-within .unit-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.unit-tooltip-title {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--accent-primary);
+  letter-spacing: 0.04em;
+}
+
+.unit-role {
+  margin: 0.35rem 0 0.6rem;
+  font-size: 0.85rem;
+  color: rgba(226, 246, 226, 0.75);
   letter-spacing: 0.01em;
+}
+
+.unit-stats {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem 0.6rem;
+}
+
+.unit-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.unit-stat dt {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(151, 236, 183, 0.85);
+}
+
+.unit-stat dd {
+  margin: 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #f5fff1;
 }
 
 .playfield {
@@ -295,8 +653,9 @@ button small {
   box-shadow: 0 26px 48px rgba(5, 16, 9, 0.6);
   background: radial-gradient(circle at 30% 10%, rgba(144, 214, 171, 0.12), transparent 60%),
     radial-gradient(circle at 70% 90%, rgba(255, 215, 122, 0.08), transparent 65%);
-  width: min(100%, clamp(620px, 70vw, 1080px));
-  justify-self: center;
+  width: 100%;
+  max-width: 1160px;
+  margin: 0 auto;
 }
 
 canvas {
@@ -335,31 +694,12 @@ canvas {
   box-shadow: 0 20px 38px rgba(31, 89, 55, 0.55);
 }
 
-.tip {
-  font-size: 0.9rem;
-  color: rgba(226, 246, 226, 0.78);
-}
-
-.objectives {
-  margin-top: 1rem;
-  background: rgba(11, 43, 24, 0.6);
-  padding: 0.95rem 1.1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(154, 214, 174, 0.4);
-  box-shadow: inset 0 0 0 1px rgba(44, 107, 66, 0.22);
-}
-
-footer {
-  font-size: 0.95rem;
-  color: var(--text-muted);
-}
-
 #status {
-  min-height: 1.35rem;
+  min-height: 1.2rem;
   opacity: 0.55;
   transition: opacity 0.3s ease, transform 0.3s ease;
-  font-size: 0.95rem;
-  letter-spacing: 0.01em;
+  font-size: 0.92rem;
+  letter-spacing: 0.02em;
 }
 
 #status.visible {
@@ -370,7 +710,7 @@ footer {
   animation: textPulse 1.2s ease;
 }
 
-button::after {
+.unit-button::after {
   content: "";
   position: absolute;
   inset: -40% -70%;
@@ -381,8 +721,8 @@ button::after {
   pointer-events: none;
 }
 
-button:hover::after,
-button:focus-visible::after {
+.unit-button:hover::after,
+.unit-button:focus-visible::after {
   opacity: 0.55;
   transform: rotate(12deg) translateY(-5%);
 }
@@ -425,39 +765,46 @@ button:focus-visible::after {
   }
 }
 
+@media (min-width: 880px) {
+  .dispatch-body {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
+  }
+}
+
 @media (max-width: 1200px) {
-  main.layout {
-    grid-template-columns: clamp(240px, 32vw, 320px) minmax(0, 1fr);
-    width: min(1100px, 96vw);
+  .dispatch {
+    gap: clamp(0.9rem, 2.2vw, 1.4rem);
   }
 
   .playfield {
-    width: min(100%, clamp(560px, 68vw, 980px));
+    max-width: 100%;
   }
 }
 
 @media (max-width: 900px) {
   main.layout {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto;
-    align-items: stretch;
     padding: clamp(0.9rem, 2.5vw, 1.25rem);
     width: min(760px, 94vw);
   }
 
-  .panel {
-    position: relative;
-    top: auto;
-    order: 2;
-    margin-bottom: clamp(0.75rem, 2vw, 1.25rem);
+  .dispatch {
+    gap: 1rem;
+  }
+
+  .dispatch-heading {
+    border-bottom: 1px solid rgba(116, 184, 143, 0.16);
+  }
+
+  .dispatch-body {
+    grid-template-columns: 1fr;
+  }
+
+  .dispatch-buttons {
+    padding: 0.65rem 0.75rem 0.75rem;
   }
 
   .hud {
     width: min(760px, calc(100% - 2rem));
-  }
-
-  .playfield {
-    width: min(100%, clamp(520px, 84vw, 920px));
   }
 }
 
@@ -466,8 +813,7 @@ button:focus-visible::after {
     font-size: 0.95rem;
   }
 
-  header.hud,
-  footer.hud {
+  header.hud {
     padding: 1rem;
     text-align: left;
   }
@@ -478,22 +824,45 @@ button:focus-visible::after {
     width: 100%;
   }
 
-  .buttons {
-    grid-template-columns: 1fr;
+  .dispatch {
+    padding: 0.85rem 0.95rem 0.9rem;
   }
 
-  button {
-    font-size: 0.95rem;
-    padding: 0.75rem 0.9rem;
+  .dispatch-buttons {
+    padding: 0.6rem 0.7rem 0.7rem;
+    gap: 0.5rem;
   }
 
-  .buttons .unit-name {
-    font-size: 1rem;
+  .unit-toolbar {
+    flex-direction: column;
+    gap: 0.55rem;
   }
 
-  .buttons .unit-stats,
-  .buttons .unit-role {
-    font-size: 0.75rem;
+  .unit-option {
+    min-width: 0;
+  }
+
+  .unit-button {
+    width: 100%;
+    min-width: 0;
+    font-size: 0.92rem;
+    padding: 0.6rem 0.7rem;
+    gap: 0.55rem;
+  }
+
+  .unit-label {
+    font-size: 0.92rem;
+  }
+
+  .unit-tooltip {
+    left: auto;
+    right: 0;
+    transform: translateY(8px);
+  }
+
+  .unit-option:hover .unit-tooltip,
+  .unit-option:focus-within .unit-tooltip {
+    transform: translateY(0);
   }
 
   .playfield {


### PR DESCRIPTION
## Summary
- restructure the Canopy Dispatch section into a compact grid with stat cards and a tagline
- slim down the caravan unit toolbar and controls to reduce the command panel footprint
- refresh status and responsive styling so the playfield dominates the layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de561d7da48325975387818a8dbf41